### PR TITLE
add payments

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,10 +1,35 @@
 class Payment < ApplicationRecord
-  belongs_to :person
+  has_paper_trail
+
+  enum method: {
+    cash: 0,
+    website: 1
+  }
 
   rails_admin do
     exclude_fields :created_at, :updated_at, :id
 
     label "Платёж"
     label_plural "Платежи"
+
+    configure :date do
+      label "Дата"
+    end
+
+    configure :name do
+      label "Имя"
+    end
+
+    configure :currency do
+      label "Валюта"
+    end
+
+    configure :amount do
+      label "Сумма"
+    end
+
+    configure :method do
+      label "Способ"
+    end
   end
 end

--- a/db/migrate/20220806151145_add_fields_to_payment.rb
+++ b/db/migrate/20220806151145_add_fields_to_payment.rb
@@ -1,0 +1,10 @@
+class AddFieldsToPayment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :payments, :name, :string
+    add_column :payments, :email, :string
+    add_column :payments, :currency, :string, default: "EUR"
+    add_column :payments, :amount, :decimal, precision: 8, scale: 2
+    add_column :payments, :method, :integer, default: 0
+    remove_column :payments, :person_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_16_182016) do
+ActiveRecord::Schema.define(version: 2022_08_06_151145) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -34,10 +34,13 @@ ActiveRecord::Schema.define(version: 2022_04_16_182016) do
 
   create_table "payments", force: :cascade do |t|
     t.date "date"
-    t.integer "person_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["person_id"], name: "index_payments_on_person_id"
+    t.string "name"
+    t.string "email"
+    t.string "currency", default: "EUR"
+    t.decimal "amount", precision: 8, scale: 2
+    t.integer "method", default: 0
   end
 
   create_table "people", force: :cascade do |t|
@@ -65,5 +68,4 @@ ActiveRecord::Schema.define(version: 2022_04_16_182016) do
   end
 
   add_foreign_key "assemblies", "people"
-  add_foreign_key "payments", "people"
 end


### PR DESCRIPTION
Payments are independent of yearly membership fees and can be made by any person, not necessarily a MAII member. `Payment` now only has optional `name` and `email` fields, which can be later used to match a `Payment` to a `Person`.