### PR TITLE
show only counts of votes and voters in the assemblies list

### DIFF
--- a/app/models/assembly.rb
+++ b/app/models/assembly.rb
@@ -6,8 +6,16 @@ class Assembly < ApplicationRecord
     Assembly.where("start_date <= ? and end_date >= ?", date, date).first
   end
 
+  def votes_count
+    votes.count
+  end
+
+  def voters_count
+    votes.select(:person_id).distinct.count
+  end
+
   rails_admin do
-    exclude_fields :created_at, :updated_at, :id
+    exclude_fields :created_at, :updated_at, :id, :votes
 
     label "Общее собрание"
     label_plural "Общие собрания"
@@ -18,6 +26,14 @@ class Assembly < ApplicationRecord
 
     configure :end_date do
       label "Дата окончания"
+    end
+
+    field :votes_count do
+      label "Голоса"
+    end
+
+    field :voters_count do
+      label "Участники"
     end
   end
 end

--- a/app/models/voting_session.rb
+++ b/app/models/voting_session.rb
@@ -6,8 +6,16 @@ class VotingSession < ApplicationRecord
     VotingSession.where("start_date <= ? and end_date >= ?", date, date).first
   end
 
+  def votes_count
+    votes.count
+  end
+
+  def voters_count
+    votes.select(:person_id).distinct.count
+  end
+
   rails_admin do
-    exclude_fields :created_at, :updated_at, :id
+    exclude_fields :created_at, :updated_at, :id, :votes
 
     label "Электронное голосование"
     label_plural "Электронные голосования"
@@ -18,6 +26,14 @@ class VotingSession < ApplicationRecord
 
     configure :end_date do
       label "Дата окончания"
+    end
+
+    field :votes_count do
+      label "Голоса"
+    end
+
+    field :voters_count do
+      label "Участники"
     end
   end
 end


### PR DESCRIPTION
rails_admin preloads all votes for all assemblies, even though it shows only a small preview. We are actually more interested in counts on that page anyway, so let’s hide the slow field and add two useful ones.

![Screenshot 2024-03-11 at 23 27 30](https://github.com/maii-chgk/register/assets/2369296/5915e2f9-d2bd-4e2c-9c58-0005ce8cd38e)
