### PR TITLE
add suspended state

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -7,7 +7,8 @@ class Person < ApplicationRecord
   MISSED_ASSEMBLIES_LIMIT = 3
 
   rails_admin do
-    include_fields :name, :cyrillic_name, :email, :discourse_username, :accepted, :newsletter, :start_date, :end_date
+    include_fields :name, :cyrillic_name, :email, :discourse_username, :accepted, :suspended, :newsletter,
+      :start_date, :end_date
     exclude_fields :created_at, :updated_at, :id
 
     label "Человек"
@@ -40,6 +41,10 @@ class Person < ApplicationRecord
     configure :discourse_username do
       label "Юзернейм на форуме"
     end
+
+    configure :suspended do
+      label "Приостановлен(а)"
+    end
   end
 
   def self.members_count
@@ -59,7 +64,7 @@ class Person < ApplicationRecord
   end
 
   def counts_toward_quorum?
-    counts_toward_quorum_on?(Date.today)
+    counts_toward_quorum_on?(Date.today) && !suspended
   end
 
   def counts_toward_quorum_on?(date)
@@ -92,7 +97,7 @@ class Person < ApplicationRecord
   end
 
   def active?
-    active_on?(Date.today)
+    active_on?(Date.today) && !suspended
   end
 
   def active_on?(date)
@@ -129,7 +134,7 @@ class Person < ApplicationRecord
   end
 
   def maybe_change_membership
-    return unless saved_change_to_accepted?
+    return unless saved_change_to_accepted? || saved_change_to_suspended?
 
     if active?
       set_discourse_role

--- a/db/migrate/20240526155512_add_suspended_to_person.rb
+++ b/db/migrate/20240526155512_add_suspended_to_person.rb
@@ -1,0 +1,5 @@
+class AddSuspendedToPerson < ActiveRecord::Migration[7.1]
+  def change
+    add_column :people, :suspended, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_19_111026) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_26_155512) do
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -53,6 +53,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_19_111026) do
     t.boolean "newsletter", default: false
     t.string "discourse_username"
     t.integer "discourse_id"
+    t.boolean "suspended"
   end
 
   create_table "versions", force: :cascade do |t|

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -92,4 +92,20 @@ class PersonTest < ActiveSupport::TestCase
     people(:camilla).update(accepted: true, end_date: nil)
     assert_equal @fake_discourse.list_group_members(Discourse::Client::MAIN_GROUP), ["camilla"]
   end
+
+  test "suspended person is not active" do
+    people(:camilla).update(suspended: true)
+    assert_not people(:camilla).active?
+  end
+
+  test "suspended person does not count towards quorum" do
+    people(:camilla).update(suspended: true)
+    assert_not people(:camilla).counts_toward_quorum?
+  end
+
+  test "suspended person is removed from discourse" do
+    @fake_discourse.add_to_group(Discourse::Client::MAIN_GROUP_ID, people(:camilla))
+    people(:camilla).update(suspended: true)
+    assert_equal @fake_discourse.list_group_members(Discourse::Client::MAIN_GROUP), []
+  end
 end


### PR DESCRIPTION
People who haven’t paid the yearly fee become suspended. They are removed from the main Discourse group and don’t count towards quorums.